### PR TITLE
Lowercase Wikidata parameter

### DIFF
--- a/20160517.解消済み仮リンクをリンクに置き換える.js
+++ b/20160517.解消済み仮リンクをリンクに置き換える.js
@@ -75,7 +75,7 @@ template_orders = {
 		foreign_language : 2,
 		// will fallback
 		foreign_title : [ 3, 1 ],
-		WD : 'WD',
+		WD : 'wd',
 		label : 'lt',
 		preserve : [ 'preserve', 'display' ]
 	},


### PR DESCRIPTION
On the [enwiki database report](https://en.wikipedia.org/wiki/Wikipedia:Database_reports/Interlanguage_link_templates_need_to_fix), all the Wikidata interlanguage links show up as syntax errors; this seems to be `normalize_parameter` lowercasing names and then checking them against an uppercase standard.