### PR TITLE
20200122.update_vital_articles.js: Use #invoke:Icon to reduce PEIS

### DIFF
--- a/routine/20200122.update_vital_articles.js
+++ b/routine/20200122.update_vital_articles.js
@@ -1459,7 +1459,7 @@ async function for_each_list_page(list_page_data) {
 					else
 						article_count_of_icon[icon] = 1;
 					//{{Class/icon}}
-					return `{{Icon|${icon}}}`;
+					return `{{#invoke:Icon||${icon}}}`;
 				});
 
 
@@ -1588,7 +1588,7 @@ async function for_each_list_page(list_page_data) {
 				const wikitext = (_item.type === 'list_item' || _item.type === 'plain') && _item.toString();
 				let PATTERN;
 				if (!wikitext) {
-				} else if ((PATTERN = /('{2,5})((?:{{Icon\|\w+}}\s*)+)/i).test(wikitext)) {
+				} else if ((PATTERN = /('{2,5})((?:{{(?:#invoke:)?Icon\|\|?\w+}}\s*)+)/i).test(wikitext)) {
 					// "{{Icon|B}} '''{{Icon|A}} {{Icon|C}} [[title]]'''" →
 					// "{{Icon|B}} {{Icon|A}} {{Icon|C}} '''[[title]]'''"
 					_item.truncate();


### PR DESCRIPTION
use `{{#invoke:Icon||${icon}}}` instead of `{{Icon|${icon}}}` to reduce [post-expand include size](https://en.wikipedia.org/wiki/Help:Template_limits#Post-expand_include_size) on pages such as [Wikipedia:Vital_articles/Level/4](https://en.wikipedia.org/wiki/Wikipedia:Vital_articles/Level/4/Philosophy_and_religion). Update regex to detect module invocations in addition to template calls. See [User_talk:Kanashimi#Icons_on_subpages_of_Wikipedia:Vital_articles/Level/4](https://en.wikipedia.org/wiki/User_talk:Kanashimi#Icons_on_subpages_of_Wikipedia:Vital_articles/Level/4)