### PR TITLE
Extract duplicated task-configuration boilerplate into shared helper

### DIFF
--- a/routine/20160323.archive_bot_logs.js
+++ b/routine/20160323.archive_bot_logs.js
@@ -29,8 +29,7 @@ function adapt_configuration(latest_task_configuration) {
 	// console.log(latest_task_configuration);
 	// console.log(wiki);
 
-	if (!latest_task_configuration.general)
-		latest_task_configuration.general = Object.create(null);
+	prepare_general_configuration(latest_task_configuration);
 
 	CeL.log('Task configuration:');
 	console.log(wiki.latest_task_configuration);

--- a/routine/20160323.archive_bot_logs.js
+++ b/routine/20160323.archive_bot_logs.js
@@ -11,6 +11,8 @@
 
 'use strict';
 
+/* global prepare_general_configuration */
+
 // globalThis.no_task_date_warning = true;
 
 // Load CeJS library and modules.

--- a/routine/20170515.signature_check.js
+++ b/routine/20170515.signature_check.js
@@ -50,6 +50,8 @@ TODO:
 
 'use strict';
 
+/* global prepare_general_configuration */
+
 // Load CeJS library and modules.
 require('../wiki loader.js');
 

--- a/routine/20170515.signature_check.js
+++ b/routine/20170515.signature_check.js
@@ -138,8 +138,7 @@ with_diff = {
 };
 
 function adapt_configuration(latest_task_configuration) {
-	var general = wiki.latest_task_configuration.general
-			|| (wiki.latest_task_configuration.general = Object.create(null));
+	var general = prepare_general_configuration(wiki.latest_task_configuration);
 
 	if (Array.isArray(general.trusted_user_groups))
 		trusted_user_privileges = new Set(general.trusted_user_groups);

--- a/routine/20190629.import_tropical_cyclone_images.js
+++ b/routine/20190629.import_tropical_cyclone_images.js
@@ -18,6 +18,8 @@
 // ----------------------------------------------------------------------------
 'use strict';
 
+/* global prepare_general_configuration */
+
 // Load CeJS library and modules.
 require('../wiki loader.js');
 

--- a/routine/20190629.import_tropical_cyclone_images.js
+++ b/routine/20190629.import_tropical_cyclone_images.js
@@ -48,8 +48,7 @@ function adapt_configuration(latest_task_configuration) {
 	// console.log(wiki);
 
 	// 一般設定
-	var general = latest_task_configuration.general
-			|| (latest_task_configuration.general = Object.create(null));
+	var general = prepare_general_configuration(latest_task_configuration);
 	if (!general) {
 		// CeL.info('No configuration.');
 	}

--- a/routine/20191129.check_language_conversion.js
+++ b/routine/20191129.check_language_conversion.js
@@ -62,9 +62,7 @@ async function adapt_configuration(latest_task_configuration) {
 
 	// ----------------------------------------------------
 
-	if (!latest_task_configuration.general)
-		latest_task_configuration.general = Object.create(null);
-	const { general } = latest_task_configuration;
+	const general = prepare_general_configuration(latest_task_configuration);
 
 	let main_category_list = general.main_category;
 	if (!Array.isArray(main_category_list))

--- a/routine/20191129.check_language_conversion.js
+++ b/routine/20191129.check_language_conversion.js
@@ -26,6 +26,8 @@ https://zh.wikipedia.org/w/index.php?title=%E7%89%B9%E7%BE%85%E4%BC%8A%C2%B7%E8%
 
 'use strict';
 
+/* global prepare_general_configuration */
+
 // Load CeJS library and modules.
 require('../wiki loader.js');
 

--- a/routine/20200122.update_vital_articles.js
+++ b/routine/20200122.update_vital_articles.js
@@ -38,6 +38,8 @@ fix [[Category:有不必要class參數的專題橫幅]]: {{德国专题 |1=B |2=
 
 'use strict';
 
+/* global prepare_general_configuration */
+
 // Load CeJS library and modules.
 require('../wiki loader.js');
 

--- a/routine/20200122.update_vital_articles.js
+++ b/routine/20200122.update_vital_articles.js
@@ -322,7 +322,7 @@ async function adapt_configuration(latest_task_configuration) {
 
 	// ----------------------------------------------------
 
-	const general = latest_task_configuration.general || (latest_task_configuration.general = Object.create(null));
+	const general = prepare_general_configuration(latest_task_configuration);
 
 	if (CeL.env.arg_hash?.base_page) {
 		// 自訂基準頁面。

--- a/routine/20200206.reminded_expired_AfD.js
+++ b/routine/20200206.reminded_expired_AfD.js
@@ -44,9 +44,7 @@ async function main_process() {
 	// console.log(wiki.latest_task_configuration);
 	// console.log(wiki.task_configuration);
 	// process.exit(1);
-	if (!wiki.latest_task_configuration.general) {
-		wiki.latest_task_configuration.general = Object.create(null);
-	}
+	prepare_general_configuration(wiki.latest_task_configuration);
 
 	if (false) {
 		await for_AfD('Wikipedia:Articles for deletion/Quintana Olleras');

--- a/routine/20200206.reminded_expired_AfD.js
+++ b/routine/20200206.reminded_expired_AfD.js
@@ -14,6 +14,8 @@ TODO:
 
 'use strict';
 
+/* global prepare_general_configuration */
+
 // Load CeJS library and modules.
 require('../wiki loader.js');
 

--- a/routine/20210411.Clean_up_the_unknown_parameters_of_the_citation_module.js
+++ b/routine/20210411.Clean_up_the_unknown_parameters_of_the_citation_module.js
@@ -39,9 +39,7 @@ async function adapt_configuration(latest_task_configuration) {
 
 	// ----------------------------------------------------
 
-	if (!latest_task_configuration.general)
-		latest_task_configuration.general = Object.create(null);
-	const { general } = latest_task_configuration;
+	const general = prepare_general_configuration(latest_task_configuration);
 
 	//console.trace(wiki.latest_task_configuration.general);
 }

--- a/routine/20210411.Clean_up_the_unknown_parameters_of_the_citation_module.js
+++ b/routine/20210411.Clean_up_the_unknown_parameters_of_the_citation_module.js
@@ -39,7 +39,7 @@ async function adapt_configuration(latest_task_configuration) {
 
 	// ----------------------------------------------------
 
-	const general = prepare_general_configuration(latest_task_configuration);
+	prepare_general_configuration(latest_task_configuration);
 
 	//console.trace(wiki.latest_task_configuration.general);
 }

--- a/routine/20210411.Clean_up_the_unknown_parameters_of_the_citation_module.js
+++ b/routine/20210411.Clean_up_the_unknown_parameters_of_the_citation_module.js
@@ -8,6 +8,8 @@ TODO:
 
 'use strict';
 
+/* global prepare_general_configuration */
+
 // Load replace tools.
 const replace_tool = require('../replace/replace_tool.js');
 

--- a/routine/20230406.Clean_up_redirected_categories.js
+++ b/routine/20230406.Clean_up_redirected_categories.js
@@ -38,9 +38,7 @@ async function adapt_configuration(latest_task_configuration) {
 
 	// ----------------------------------------------------
 
-	if (!latest_task_configuration.general)
-		latest_task_configuration.general = Object.create(null);
-	const { general } = latest_task_configuration;
+	const general = prepare_general_configuration(latest_task_configuration);
 
 	if (!general.redirect_template_name)
 		general.redirect_template_name = 'Template:Category redirect';

--- a/routine/20230406.Clean_up_redirected_categories.js
+++ b/routine/20230406.Clean_up_redirected_categories.js
@@ -13,6 +13,8 @@ node 20230406.Clean_up_redirected_categories.js use_project=zh.wikinews
 
 'use strict';
 
+/* global prepare_general_configuration */
+
 // Load replace tools.
 const replace_tool = require('../replace/replace_tool.js');
 

--- a/routine/20230418.Fix_redirected_wikilinks_of_templates.js
+++ b/routine/20230418.Fix_redirected_wikilinks_of_templates.js
@@ -59,7 +59,7 @@ async function adapt_configuration(latest_task_configuration) {
 
 	// ----------------------------------------------------
 
-	const general = prepare_general_configuration(latest_task_configuration);
+	prepare_general_configuration(latest_task_configuration);
 
 	//
 

--- a/routine/20230418.Fix_redirected_wikilinks_of_templates.js
+++ b/routine/20230418.Fix_redirected_wikilinks_of_templates.js
@@ -20,6 +20,8 @@ TODO:
 
 'use strict';
 
+/* global prepare_general_configuration */
+
 // Load CeJS library and modules.
 require('../wiki loader.js');
 

--- a/routine/20230418.Fix_redirected_wikilinks_of_templates.js
+++ b/routine/20230418.Fix_redirected_wikilinks_of_templates.js
@@ -59,9 +59,7 @@ async function adapt_configuration(latest_task_configuration) {
 
 	// ----------------------------------------------------
 
-	if (!latest_task_configuration.general)
-		latest_task_configuration.general = Object.create(null);
-	const { general } = latest_task_configuration;
+	const general = prepare_general_configuration(latest_task_configuration);
 
 	//
 

--- a/routine/20240821.Clean_up_misspelling_links.js
+++ b/routine/20240821.Clean_up_misspelling_links.js
@@ -33,9 +33,7 @@ async function adapt_configuration(latest_task_configuration) {
 
 	// ----------------------------------------------------
 
-	if (!latest_task_configuration.general)
-		latest_task_configuration.general = Object.create(null);
-	const { general } = latest_task_configuration;
+	const general = prepare_general_configuration(latest_task_configuration);
 
 	console.trace(wiki.latest_task_configuration.general);
 }

--- a/routine/20240821.Clean_up_misspelling_links.js
+++ b/routine/20240821.Clean_up_misspelling_links.js
@@ -10,6 +10,8 @@ node 20240821.Clean_up_misspelling_links.js use_project=zh
 
 'use strict';
 
+/* global prepare_general_configuration */
+
 // Load replace tools.
 const replace_tool = require('../replace/replace_tool.js');
 

--- a/routine/20240821.Clean_up_misspelling_links.js
+++ b/routine/20240821.Clean_up_misspelling_links.js
@@ -33,7 +33,7 @@ async function adapt_configuration(latest_task_configuration) {
 
 	// ----------------------------------------------------
 
-	const general = prepare_general_configuration(latest_task_configuration);
+	prepare_general_configuration(latest_task_configuration);
 
 	console.trace(wiki.latest_task_configuration.general);
 }

--- a/routine/20251126.Move_exposed_template_Collapsible_option_to_Navbox_documentation.js
+++ b/routine/20251126.Move_exposed_template_Collapsible_option_to_Navbox_documentation.js
@@ -15,6 +15,8 @@ TODO:
 
 'use strict';
 
+/* global prepare_general_configuration */
+
 // Load CeJS library and modules.
 require('../wiki loader.js');
 

--- a/routine/20251126.Move_exposed_template_Collapsible_option_to_Navbox_documentation.js
+++ b/routine/20251126.Move_exposed_template_Collapsible_option_to_Navbox_documentation.js
@@ -55,9 +55,7 @@ async function adapt_configuration(latest_task_configuration) {
 
 	// ----------------------------------------------------
 
-	if (!latest_task_configuration.general)
-		latest_task_configuration.general = Object.create(null);
-	const { general } = latest_task_configuration;
+	const general = prepare_general_configuration(latest_task_configuration);
 
 	if (!(0 <= general.max_TDOC_subpage_chars_to_move && general.max_TDOC_subpage_chars_to_move < 200_000)) {
 		general.max_TDOC_subpage_chars_to_move = 2_000;

--- a/routine/20260422.auto_subst_templates.js
+++ b/routine/20260422.auto_subst_templates.js
@@ -12,6 +12,8 @@ TODO:
 
 'use strict';
 
+/* global prepare_general_configuration */
+
 const debug_pages = ['Template:Infobox Twitch streamer', 'Template:Infobox bilibili personality', 'Template:Infobox YouTube personality']
 	&& ['Template:台北捷運色彩']
 	&& ['Template:无锡地铁颜色']

--- a/routine/20260422.auto_subst_templates.js
+++ b/routine/20260422.auto_subst_templates.js
@@ -49,9 +49,7 @@ async function adapt_configuration(latest_task_configuration) {
 
 	// ----------------------------------------------------
 
-	if (!latest_task_configuration.general)
-		latest_task_configuration.general = Object.create(null);
-	const { general } = latest_task_configuration;
+	const general = prepare_general_configuration(latest_task_configuration);
 
 	if (!(0 <= general.max_pages_before_abort && general.max_pages_before_abort <= 500)) {
 		// 不取代超過一定嵌入數量的模板。預設為100個。

--- a/routine/20260620.convert_interwiki_links.js
+++ b/routine/20260620.convert_interwiki_links.js
@@ -14,6 +14,8 @@ TODO:
 
 'use strict';
 
+/* global prepare_general_configuration */
+
 const debug_pages =
 	['澤蘭宮']
 	&& ['Wikipedia:沙盒'] && ['User:Cewbot/log/20260620/testcases']

--- a/routine/20260620.convert_interwiki_links.js
+++ b/routine/20260620.convert_interwiki_links.js
@@ -59,7 +59,7 @@ async function adapt_configuration(latest_task_configuration) {
 
 	// ----------------------------------------------------
 
-	const general = prepare_general_configuration(latest_task_configuration);
+	prepare_general_configuration(latest_task_configuration);
 
 
 	console.trace(wiki.latest_task_configuration.general);

--- a/routine/20260620.convert_interwiki_links.js
+++ b/routine/20260620.convert_interwiki_links.js
@@ -59,9 +59,7 @@ async function adapt_configuration(latest_task_configuration) {
 
 	// ----------------------------------------------------
 
-	if (!latest_task_configuration.general)
-		latest_task_configuration.general = Object.create(null);
-	const { general } = latest_task_configuration;
+	const general = prepare_general_configuration(latest_task_configuration);
 
 
 	console.trace(wiki.latest_task_configuration.general);

--- a/wiki loader.js
+++ b/wiki loader.js
@@ -373,6 +373,15 @@ _global.prepare_directory = function prepare_directory(directory, clean) {
 	CeL.create_directory(directory);
 };
 
+// 確保 latest_task_configuration.general 存在並回傳之。
+// Ensure `.general` of the task configuration exists, then return it.
+// e.g., const general = prepare_general_configuration(latest_task_configuration);
+_global.prepare_general_configuration = function prepare_general_configuration(
+		latest_task_configuration) {
+	return latest_task_configuration.general
+			|| (latest_task_configuration.general = Object.create(null));
+};
+
 if (!_global.fetch) {
 	_global.fetch = function fetch(url) {
 		if (CeL.platform.is_interactive) {

--- a/wiki loader.js
+++ b/wiki loader.js
@@ -378,8 +378,9 @@ _global.prepare_directory = function prepare_directory(directory, clean) {
 // e.g., const general = prepare_general_configuration(latest_task_configuration);
 _global.prepare_general_configuration = function prepare_general_configuration(
 		latest_task_configuration) {
-	return latest_task_configuration.general
-			|| (latest_task_configuration.general = Object.create(null));
+	if (!latest_task_configuration.general)
+		latest_task_configuration.general = Object.create(null);
+	return latest_task_configuration.general;
 };
 
 if (!_global.fetch) {


### PR DESCRIPTION
## Summary
13 `routine/*.js` scripts each re-implemented the same idiom inside their `adapt_configuration` / `main_process` to make sure `latest_task_configuration.general` is a plain object before using it. This extracts that idiom into a single shared helper in `wiki loader.js` (already required, directly or transitively, by every script), removing the copy-paste.

New helper:
```js
_global.prepare_general_configuration = function (latest_task_configuration) {
	if (!latest_task_configuration.general)
		latest_task_configuration.general = Object.create(null);
	return latest_task_configuration.general;
};
```

Call sites collapse from e.g.
```js
if (!latest_task_configuration.general)
	latest_task_configuration.general = Object.create(null);
const { general } = latest_task_configuration;
```
to
```js
const general = prepare_general_configuration(latest_task_configuration);
```
(or just a bare `prepare_general_configuration(...)` call where the local `general` binding was unused).

The helper returns the same object reference and creates it with a `null` prototype exactly as before, so behavior is unchanged. Variants that read `wiki.latest_task_configuration` pass that object in. Each consumer gets a `/* global prepare_general_configuration */` declaration, matching the repo's existing `/* global CeL */` / `/* global Wiki */` convention for loader-provided globals (keeps Codacy's ESLint `no-undef` clean).

`20201008.fix_anchor.js` was intentionally left untouched — it emits a `CeL.error` when `general` is missing (different behavior), so it isn't a clean fit for this helper.

Duplication was located with `jscpd`; this idiom was the most widespread cross-file clone. Each edited file passes `node --check`, and DeepScan reports 0 new / 5 fixed issues.


Link to Devin session: https://app.devin.ai/sessions/bfaf33edf98e4865a8711503ce377cb5
Requested by: @kanasimi