### PR TITLE
Add unit tests for the tool functions of replace_tool and special page configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+package-lock.json
+# private: contains the bot account name and password
+wiki configuration.js

--- a/README.md
+++ b/README.md
@@ -190,6 +190,20 @@ wiki.edit_data(function(entity) {
 ```
 
 
+### Tests
+
+Unit tests of the tool functions are put in [test/](https://github.com/kanasimi/wikibot/tree/master/test) and run with the [node:test](https://nodejs.org/api/test.html) runner. They do not contact any wiki.
+
+```bash
+npm install
+npm test
+# with a coverage report:
+npm run test:coverage
+```
+
+The tests need `wiki configuration.js`; it is created from `wiki configuration.sample.js` automatically when missing.
+
+
 ## Screenshot
 Screenshot of [WPCHECK.js](https://github.com/kanasimi/wikibot/blob/master/routine/20151002.WPCHECK.js) (fix_16 only):
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,11 @@
 		"url" : "https://github.com/kanasimi/wikibot.git"
 	},
 
+	"scripts" : {
+		"test" : "node --test test/",
+		"test:coverage" : "node --test --experimental-test-coverage test/"
+	},
+
 	"devDependencies" : {
 	},
 	"dependencies" : {

--- a/replace/replace_tool.js
+++ b/replace/replace_tool.js
@@ -1668,7 +1668,7 @@ function text_processor_for_exturlusage(wikitext, page_data) {
 		// .all_link_pattern
 		// [\/]: 避免 https://web.archive.org/web/000000/http://www.example.com/
 		// TODO: flag: 'ig'
-		const PATTERN_url = new RegExp('(^|\W)' + CeL.to_RegExp_pattern(move_from_link), 'g');
+		const PATTERN_url = new RegExp('(^|\\W)' + CeL.to_RegExp_pattern(move_from_link), 'g');
 		// console.trace(PATTERN_url);
 		wikitext = wikitext.replace(PATTERN_url, function (all, prefix) {
 			changed = true;
@@ -3549,6 +3549,14 @@ module.exports = {
 	// for modify
 	replace: replace_tool__replace,
 	remove_duplicated_display_text,
+
+	// tool functions
+	convert_special_move_to,
+	unshift_move_configuration,
+	normalize_page_title_token,
+	remove_slash_tail,
+	text_processor_for_search,
+	text_processor_for_exturlusage,
 
 	// for move
 	parse_move_pairs_from_page,

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,0 +1,29 @@
+/**
+ * @name Common setup for unit tests.
+ * @fileoverview Loads the CeJS wiki library the same way the bot scripts do,
+ *               without contacting any wiki. "wiki configuration.js" is
+ *               required by "wiki loader.js"; create it from the sample when
+ *               the working copy does not have one yet.
+ */
+
+'use strict';
+
+const node_fs = require('fs');
+const path = require('path');
+
+const base_directory = path.join(__dirname, '..');
+const configuration_file = path.join(base_directory, 'wiki configuration.js');
+
+if (!node_fs.existsSync(configuration_file)) {
+	node_fs.copyFileSync(path.join(base_directory,
+			'wiki configuration.sample.js'), configuration_file);
+}
+
+globalThis.no_task_date_warning = true;
+
+require(path.join(base_directory, 'wiki loader.js'));
+
+module.exports = {
+	base_directory,
+	CeL: globalThis.CeL
+};

--- a/test/replace_tool.test.js
+++ b/test/replace_tool.test.js
@@ -1,0 +1,192 @@
+/**
+ * @name Unit tests of replace/replace_tool.js tool functions.
+ */
+
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+
+const { CeL } = require('./helper.js');
+const replace_tool = require('../replace/replace_tool.js');
+
+describe('remove_slash_tail', () => {
+	const { remove_slash_tail } = replace_tool;
+
+	it('removes the tail slash of a domain only URL', () => {
+		assert.strictEqual(remove_slash_tail('http://www.example.com/'),
+				'http://www.example.com');
+		assert.strictEqual(remove_slash_tail('https://www.example.com/'),
+				'https://www.example.com');
+	});
+
+	it('keeps the tail slash of an URL with path', () => {
+		assert.strictEqual(remove_slash_tail('http://www.example.com/path/'),
+				'http://www.example.com/path/');
+	});
+
+	it('keeps URLs without tail slash', () => {
+		assert.strictEqual(remove_slash_tail('http://www.example.com'),
+				'http://www.example.com');
+		assert.strictEqual(remove_slash_tail('http://www.example.com/path'),
+				'http://www.example.com/path');
+	});
+});
+
+describe('convert_special_move_to', () => {
+	const { convert_special_move_to } = replace_tool;
+
+	it('converts the special keywords to their symbols', () => {
+		assert.strictEqual(convert_special_move_to('DELETE_PAGE'),
+				globalThis.DELETE_PAGE);
+		assert.strictEqual(convert_special_move_to('REDIRECT_TARGET'),
+				globalThis.REDIRECT_TARGET);
+	});
+
+	it('keeps other move targets', () => {
+		assert.strictEqual(convert_special_move_to('subst:'), 'subst:');
+		assert.strictEqual(convert_special_move_to('Page title'), 'Page title');
+		assert.strictEqual(convert_special_move_to(undefined), undefined);
+	});
+
+	it('converts .move_to_link of a configuration object in place', () => {
+		const configuration = { move_to_link: 'DELETE_PAGE', extra: 1 };
+		assert.strictEqual(convert_special_move_to(configuration),
+				configuration);
+		assert.strictEqual(configuration.move_to_link, globalThis.DELETE_PAGE);
+		assert.strictEqual(configuration.extra, 1);
+	});
+});
+
+describe('unshift_move_configuration', () => {
+	const { unshift_move_configuration } = replace_tool;
+
+	it('returns the original configuration when there is nothing to unshift',
+			() => {
+				const move_configuration = { from: 'to' };
+				assert.strictEqual(unshift_move_configuration(
+						move_configuration, undefined), move_configuration);
+			});
+
+	it('prepends the items to an {Object} configuration', () => {
+		assert.deepStrictEqual(unshift_move_configuration({ b: '2' },
+				{ a: '1' }), { a: '1', b: '2' });
+	});
+
+	it('lets the original configuration overwrite the unshifted items', () => {
+		assert.deepStrictEqual(unshift_move_configuration({ a: 'new' },
+				{ a: 'old' }), { a: 'new' });
+	});
+
+	it('prepends the items as pairs to an {Array} configuration', () => {
+		assert.deepStrictEqual(unshift_move_configuration([['b', '2']],
+				{ a: '1' }), [['a', '1'], ['b', '2']]);
+	});
+});
+
+describe('normalize_page_title_token', () => {
+	const { normalize_page_title_token } = replace_tool;
+
+	it('trims the title', () => {
+		assert.strictEqual(normalize_page_title_token('  Page title \n'),
+				'Page title');
+	});
+
+	it('unifies the small ヶ to the normal ケ', () => {
+		assert.strictEqual(normalize_page_title_token('鎌ヶ谷スタジアム'),
+				'鎌ケ谷スタジアム');
+	});
+
+	it('accepts a parsed token instead of a string', () => {
+		const token = CeL.wiki.parser('鎌ヶ谷市').parse();
+		assert.strictEqual(normalize_page_title_token(token), '鎌ケ谷市');
+	});
+});
+
+describe('text_processor_for_search', () => {
+	const { text_processor_for_search } = replace_tool;
+
+	it('replaces .replace_from with .move_to_link', () => {
+		const task_configuration = {
+			replace_from: /old/g,
+			move_to_link: 'new'
+		};
+		assert.strictEqual(text_processor_for_search.call(task_configuration,
+				'an old old text'), 'an new new text');
+	});
+});
+
+describe('text_processor_for_exturlusage', () => {
+	const { text_processor_for_exturlusage } = replace_tool;
+
+	it('replaces the external link in wikitext', () => {
+		const task_configuration = {
+			move_from_link: 'http://old.example.com',
+			move_to_link: 'https://new.example.com'
+		};
+		assert.strictEqual(text_processor_for_exturlusage.call(
+				task_configuration, 'see [http://old.example.com/page here]'),
+				'see [https://new.example.com/page here]');
+	});
+
+	it('returns a falsy value when there is nothing changed', () => {
+		const task_configuration = {
+			move_from_link: 'http://old.example.com',
+			move_to_link: 'https://new.example.com'
+		};
+		assert.ok(!text_processor_for_exturlusage.call(task_configuration,
+				'see [http://other.example.com/page here]'));
+	});
+
+	it('does not generate a double slash', () => {
+		const task_configuration = {
+			move_from_link: 'http://old.example.com/path/',
+			move_to_link: 'https://new.example.com/path'
+		};
+		assert.strictEqual(text_processor_for_exturlusage.call(
+				task_configuration, 'http://old.example.com/path/page'),
+				'https://new.example.com/path/page');
+	});
+
+	it('accepts .move_to_url as the replacement of .move_to_link', () => {
+		const task_configuration = {
+			move_from_link: 'http://old.example.com',
+			move_to_url: 'https://new.example.com'
+		};
+		assert.strictEqual(text_processor_for_exturlusage.call(
+				task_configuration, 'http://old.example.com/page'),
+				'https://new.example.com/page');
+	});
+});
+
+describe('remove_duplicated_display_text', () => {
+	const { remove_duplicated_display_text } = replace_tool;
+
+	function link_token_of(wikitext) {
+		const parsed = CeL.wiki.parser(wikitext).parse();
+		let link_token;
+		parsed.each('link', token => {
+			link_token = token;
+		});
+		assert.ok(link_token, 'got the link token of ' + wikitext);
+		return link_token;
+	}
+
+	it('removes the displayed text same as the page title', () => {
+		const token = link_token_of('[[Page title|Page title]]');
+		remove_duplicated_display_text(token);
+		assert.strictEqual(token.toString(), '[[Page title]]');
+	});
+
+	it('keeps a different displayed text', () => {
+		const token = link_token_of('[[Page title|other text]]');
+		remove_duplicated_display_text(token);
+		assert.strictEqual(token.toString(), '[[Page title|other text]]');
+	});
+
+	it('keeps the displayed text with styles', () => {
+		const token = link_token_of("[[Page title|'''Page title''']]");
+		remove_duplicated_display_text(token);
+		assert.strictEqual(token.toString(), "[[Page title|'''Page title''']]");
+	});
+});

--- a/test/special_page_configuration.test.js
+++ b/test/special_page_configuration.test.js
@@ -1,0 +1,147 @@
+/**
+ * @name Unit tests of the tool functions of "special page configuration.js".
+ */
+
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+
+require('./helper.js');
+const special_page_configuration = require('../special page configuration.js');
+
+describe('generate_headers', () => {
+	const { generate_headers } = special_page_configuration;
+
+	it('generates the header of each column', () => {
+		const page_configuration = { columns: 'title;discussions' };
+		const headers = generate_headers(page_configuration);
+		assert.ok(headers.startsWith('! '));
+		assert.strictEqual(headers.split(' !! ').length, 2);
+	});
+
+	it('caches the generated headers at .headers', () => {
+		const page_configuration = { columns: 'NO;title' };
+		assert.strictEqual(generate_headers(page_configuration),
+				page_configuration.headers);
+	});
+
+	it('does not overwrite the assigned .headers', () => {
+		const page_configuration = {
+			columns: 'NO;title',
+			headers: '! assigned'
+		};
+		assert.strictEqual(generate_headers(page_configuration), '! assigned');
+	});
+
+	it('prefers .column_to_header of the page configuration', () => {
+		const page_configuration = {
+			columns: 'title',
+			column_to_header: { title: 'local header' }
+		};
+		assert.strictEqual(generate_headers(page_configuration),
+				'! local header');
+	});
+});
+
+describe('is_bot_user', () => {
+	const { is_bot_user } = special_page_configuration;
+	const using_special_users = { bot: { 'Listed bot': true } };
+
+	it('recognizes the users listed in .bot', () => {
+		assert.ok(is_bot_user('Listed bot', null, using_special_users));
+	});
+
+	it('recognizes the user names looks like a bot', () => {
+		assert.ok(is_bot_user('Cewbot', null, using_special_users));
+	});
+
+	it('does not recognize a normal user name', () => {
+		assert.ok(!is_bot_user('Kanashimi', null, using_special_users));
+	});
+});
+
+describe('if_too_long', () => {
+	const { if_too_long } = special_page_configuration;
+
+	it('reports a short title as not too long', () => {
+		assert.strictEqual(if_too_long('Short title'), false);
+	});
+
+	it('reports a long title as too long', () => {
+		assert.strictEqual(if_too_long('long title '.repeat(10)), true);
+	});
+
+	it('ignores HTML tags and styles when measuring the width', () => {
+		assert.strictEqual(if_too_long("<small>'''Short title'''</small>"),
+				false);
+	});
+
+	it('measures CJK characters as double width', () => {
+		// 21 CJK characters === 42 > 40
+		assert.strictEqual(if_too_long('話'.repeat(21)), true);
+		assert.strictEqual(if_too_long('話'.repeat(19)), false);
+	});
+});
+
+describe('data_sort_attributes', () => {
+	const { data_sort_attributes } = special_page_configuration;
+
+	it('generates the sort value of a string', () => {
+		assert.strictEqual(data_sort_attributes('key'),
+				'data-sort-value="key" ');
+	});
+
+	it('adds the number sort type', () => {
+		assert.strictEqual(data_sort_attributes(12),
+				'data-sort-type="number" data-sort-value="12" ');
+	});
+
+	it('adds the isoDate sort type of a {Date}', () => {
+		const date = new Date(Date.UTC(2020, 0, 2, 3, 4, 5));
+		assert.strictEqual(data_sort_attributes(date),
+				'data-sort-type="isoDate" data-sort-value="'
+						+ date.toISOString() + '" ');
+	});
+});
+
+describe('local_number', () => {
+	const { local_number } = special_page_configuration;
+
+	it('generates the right aligned style attributes', () => {
+		assert.strictEqual(local_number(3),
+				'style="text-align: right;" | 3');
+	});
+
+	it('appends the style to attributes without style', () => {
+		assert.strictEqual(local_number(3, 'colspan="2"'),
+				'colspan="2" style="text-align: right;" | 3');
+	});
+
+	it('inserts the style into the existing style attribute', () => {
+		assert.strictEqual(local_number(3, 'style="color: red;"'),
+				'style="text-align: right;color: red;" | 3');
+	});
+
+	it('accepts the additional style', () => {
+		assert.strictEqual(local_number(3, null, 'color: red;'),
+				'style="color: red;text-align: right;" | 3');
+	});
+});
+
+describe('adapt_configuration_to_page', () => {
+	const { adapt_configuration_to_page, if_too_long }
+			= special_page_configuration;
+
+	it('applies general.max_title_length of the page configuration', () => {
+		try {
+			adapt_configuration_to_page({ general: { max_title_length: 5 } });
+			assert.strictEqual(if_too_long('long enough'), true);
+			adapt_configuration_to_page({ general: { max_title_length: 100 } });
+			assert.strictEqual(if_too_long('long enough'), false);
+		} finally {
+			// reset to the default configuration
+			adapt_configuration_to_page(undefined);
+		}
+	});
+});


### PR DESCRIPTION
## Summary

The repo had no test infrastructure at all (no `test` script, no framework, no CI), so coverage was 0% for every file. Only two files are `require()`-able modules rather than one-shot bot scripts — `replace/replace_tool.js` and `special page configuration.js` — so this adds a `node:test` suite (no new dependencies) covering their pure tool functions: 41 tests, all offline.

- `npm test` → `node --test test/`, `npm run test:coverage` → same with `--experimental-test-coverage`.
- `test/helper.js` loads `wiki loader.js` the way the bot scripts do, and creates `wiki configuration.js` from the sample when missing, so tests run on a fresh clone without credentials.
- `replace/replace_tool.js`: exported the already-pure helpers (`convert_special_move_to`, `unshift_move_configuration`, `normalize_page_title_token`, `remove_slash_tail`, `text_processor_for_search`, `text_processor_for_exturlusage`) so they can be tested; no behavioral change to the exports used by task files.
- Added `.gitignore` for `node_modules/`, `package-lock.json` and the private `wiki configuration.js`.

One real bug found while testing `text_processor_for_exturlusage`: the URL pattern was built from a normal string, so `'\W'` collapsed to the literal `W` and URLs were only replaced at the very start of the wikitext (i.e. `see [http://old.example.com/page]` was left untouched).

```diff
-new RegExp('(^|\W)' + CeL.to_RegExp_pattern(move_from_link), 'g')
+new RegExp('(^|\\W)' + CeL.to_RegExp_pattern(move_from_link), 'g')
```

Not covered (needs a live wiki session): `get_all_sections`, `main_move_process`, `parse_move_pairs_from_page` and the rest of the API-driven flow. Those would need an injectable session/HTTP mock to be testable.


Link to Devin session: https://app.devin.ai/sessions/7b5c7d5e46cc4ce39db5e8d0cc5839a1
Requested by: @kanasimi