### PR TITLE
security: add .gitignore for credentials and remove eval() on remote content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# Private credential / configuration files.
+# The README instructs users to copy "wiki configuration.sample.js" to
+# "wiki configuration.js" and fill in real bot usernames / passwords.
+# Never commit that file (or any local secrets).
+wiki configuration.js
+*.local.js
+.env
+.env.*
+!.env.example
+
+# Dependencies
+node_modules/
+package-lock.json
+
+# Logs / caches / runtime artifacts
+*.log
+npm-debug.log*
+*.csv
+*.lst
+dumps/
+cache/
+
+# OS / editor cruft
+.DS_Store
+Thumbs.db
+*.swp
+.idea/
+.vscode/

--- a/routine/20190629.import_tropical_cyclone_images.js
+++ b/routine/20190629.import_tropical_cyclone_images.js
@@ -1330,7 +1330,16 @@ function start_JMA() {
 		/** ************************************************************************** */
 		// -->
 		// </script>
-		eval(html.between('var typhoonList=', '</script>').between(';', '/*'));
+		// Extract the `typhoonList[index]="id";` assignments from the remote
+		// page without eval(), so a manipulated/compromised response cannot
+		// execute arbitrary code on the bot host.
+		var typhoon_list_code = html.between('var typhoonList=', '</script>')
+				.between(';', '/*'),
+		//
+		PATTERN_typhoon_id = /typhoonList\s*\[\s*\d+\s*\]\s*=\s*(["'])([^"']*)\1/g, matched_typhoon_id;
+		while (matched_typhoon_id = PATTERN_typhoon_id.exec(typhoon_list_code)) {
+			typhoonList.push(matched_typhoon_id[2]);
+		}
 		typhoonList.forEach(function(id) {
 			var media_data = {
 				id : id,


### PR DESCRIPTION
## Summary

Fixes the two critical issues found in a security scan of the repo (a collection of standalone MediaWiki bot scripts — no web server, so no CORS/auth/debug-endpoint surface).

**1. No `.gitignore` → credential-leak risk (highest impact).** The README setup tells users to copy `wiki configuration.sample.js` to `wiki configuration.js` and fill in real bot usernames/passwords, and `wiki loader.js` does `require('./wiki configuration.js')`. With no `.gitignore`, that secret file (and `node_modules/`) can easily be committed. Added a `.gitignore` that excludes `wiki configuration.js`, `.env*`, `node_modules/`, and common runtime artifacts. Verified no currently-tracked files are ignored, and the pattern does not match the legitimately-committed `special page configuration.js`.

**2. `eval()` on remotely-fetched content → remote code execution.** `routine/20190629.import_tropical_cyclone_images.js` did:

```js
eval(html.between('var typhoonList=', '</script>').between(';', '/*'));
```

on the response from `jma.go.jp`. A manipulated/compromised response would run arbitrary code on the bot host. Replaced with a regex that extracts the `typhoonList[i]="id"` assignments — same resulting array, no code execution:

```js
var PATTERN_typhoon_id = /typhoonList\s*\[\s*\d+\s*\]\s*=\s*(["'])([^"']*)\1/g, m;
while (m = PATTERN_typhoon_id.exec(typhoon_list_code)) typhoonList.push(m[2]);
```

## Findings not changed here (no code touched)

- **`eval(html.between('='))` in `routine/20180511.headline.js`** (`parser_東方日報`): same RCE class, but the remote payload is JS object literals of unknown shape, so a safe rewrite risks breaking parsing. Recommend converting to a bounded parser; flagged for owner review.
- **Unpinned deps** (`cejs`/`wikiapi`/`gh-updater` = `"latest"` in `package.json`): supply-chain risk; recommend pinning to reviewed versions.
- **Not exploitable / operator-trusted, left as-is:** SQL in `task/process_dump.js` (parameterized `INSERT`; `DROP`/`CREATE` use a constant table name), `eval()` over an internal counter in `traversal_pages.js`, and `child_process` calls (array args / constant URLs / dead code) in the Tool-Labs importer scripts. No hardcoded secrets found in the tree or history.


Link to Devin session: https://app.devin.ai/sessions/d9897a4abe2746b9ad05a27ad08a402f
Requested by: @kanasimi