### PR TITLE
Report errors instead of silently swallowing them

### DIFF
--- a/check_parser.js
+++ b/check_parser.js
@@ -34,6 +34,13 @@ var skip_exists = false,
 //
 check_OK = 0, check_error = 0;
 
+function report_write_error(error) {
+	if (error) {
+		CeL.error('Cannot write file:');
+		console.error(error);
+	}
+}
+
 function check_page(page_data) {
 	if (!CeL.wiki.content_of.page_exists(page_data))
 		return;
@@ -79,8 +86,10 @@ function check_page(page_data) {
 		check_OK++;
 	} else {
 		CeL.warn('[[' + title + ']]: different contents!');
-		node_fs.writeFile(file_name_prefix + 'original.txt', content);
-		node_fs.writeFile(file_name_prefix + 'parsed.txt', parsed_String);
+		node_fs.writeFile(file_name_prefix + 'original.txt', content,
+				report_write_error);
+		node_fs.writeFile(file_name_prefix + 'parsed.txt', parsed_String,
+				report_write_error);
 		if (check_error++ > 9)
 			throw new Error('check_page: Too many errors');
 	}
@@ -102,7 +111,13 @@ var node_fs = require('fs');
 
 function check_index(index) {
 	CeL.get_URL_cache(checkwiki_api_URL + index, function(page_list) {
-		page_list = JSON.parse(page_list);
+		try {
+			page_list = JSON.parse(page_list);
+		} catch (e) {
+			CeL.error('check_index: Invalid page list of index ' + index + ': '
+					+ e);
+			return;
+		}
 		// CeL.set_debug(3);
 		if (page_list.length === 0)
 			return;

--- a/replace/replace_tool.js
+++ b/replace/replace_tool.js
@@ -630,6 +630,7 @@ async function get_move_configuration_from_section(meta_configuration, section, 
 			task_configuration = JSON.parse(tag_token[1].toString());
 		} catch (e) {
 			CeL.error(`${get_move_configuration_from_section.name}: ${e}`);
+			return;
 		}
 		//console.trace(task_configuration);
 
@@ -871,12 +872,15 @@ async function get_move_configuration_from_section(meta_configuration, section, 
 					});
 					eval('task_options = ' + task_options);
 					//console.trace(task_options);
-				} else if (!options?.no_export) {
+				} else {
 					CeL.error({
 						// gettext_config:{"id":"not-json-you-may-want-to-set-allow_eval=true-$1"}
 						T: ['Not JSON, you may want to set "allow_eval=true": %1', task_options]
 					});
-					throw e;
+					if (!options?.no_export)
+						throw e;
+					// 匯出設定時不中斷作業，但亦不可採用無法解析的設定。
+					task_options = undefined;
 				}
 			}
 			//console.log(task_options);

--- a/routine/20160414.import_label_from_wiki_link.js
+++ b/routine/20160414.import_label_from_wiki_link.js
@@ -240,6 +240,9 @@ function try_decode(title) {
 		try {
 			return decodeURIComponent(title);
 		} catch (e) {
+			// e.g., URIError: URI malformed. 不是合法的 URI encoding，改用原文。
+			CeL.debug('try_decode: Cannot decode ' + JSON.stringify(title)
+					+ ': ' + e, 2);
 		}
 	}
 	// for '&#x0259;'
@@ -1727,7 +1730,11 @@ try {
 	require('fs').unlinkSync(
 			base_directory + 'all_pages.' + CeL.wiki.site_name(wiki) + '.json');
 } catch (e) {
-	// TODO: handle exception
+	if (e.code !== 'ENOENT') {
+		// 尚未建立 cache 時 (ENOENT) 屬正常情況；其餘例如權限問題則必須報告。
+		CeL.error('Cannot delete the cache of all pages:');
+		console.error(e);
+	}
 }
 
 if (!modify_Wikipedia) {

--- a/routine/20160915.TaiBNET.js
+++ b/routine/20160915.TaiBNET.js
@@ -27,16 +27,13 @@ var now = new Date(),
 TaiBNET_CSV_path = base_directory + 'TaiwanSpecies_UTF8.'
 		+ now.format('%Y%2m%2d') + '.csv';
 
-try {
-	var node_fs = require('fs');
-	// check if file exists
-	if (node_fs.statSync(TaiBNET_CSV_path)) {
-		import_data();
-	}
-} catch (e) {
-	// console.error(e);
-	// throw e;
+var node_fs = require('fs');
+// check if file exists. 檔案不存在時才下載，因此不可將 import_data() 的錯誤也當作檔案不存在。
+var CSV_file_exists = node_fs.existsSync(TaiBNET_CSV_path);
 
+if (CSV_file_exists) {
+	import_data();
+} else {
 	// http://taibnet.sinica.edu.tw/chi/taibnet_xcsv.php?R1=name&D1=&D2=&D3=&T1=&T2=%25&id=&sy=y&pi=&da=
 	var url = 'http://taibnet.sinica.edu.tw/chi/taibnet_xcsv.php?R1=name&D1=&D2=&D3=&T1=&T2=%25&id=&sy=y&pi=&da=', spawn = require('child_process').spawn, get_TaiBNET_file = spawn(
 			'/usr/bin/wget', [ '--output-document=' + TaiBNET_CSV_path + '',
@@ -51,12 +48,19 @@ try {
 		// console.error(data.toString());
 	});
 
+	get_TaiBNET_file.on('error', function(error) {
+		// e.g., /usr/bin/wget does not exist.
+		CeL.error('Cannot execute wget to get [' + url + ']:');
+		console.error(error);
+		process.exitCode = 1;
+	});
+
 	get_TaiBNET_file.on('close', function(exit) {
 		if (exit === 0) {
 			import_data();
 		} else {
-			throw 'Cannot get file [' + TaiBNET_CSV_path + ']: exit code '
-					+ exit;
+			throw new Error('Cannot get file [' + TaiBNET_CSV_path
+					+ ']: exit code ' + exit);
 		}
 	});
 }

--- a/routine/20200122.update_vital_articles.js
+++ b/routine/20200122.update_vital_articles.js
@@ -2544,6 +2544,8 @@ async function maintain_VA_template(options) {
 			});
 		}
 	} catch (e) {
+		CeL.error(`${maintain_VA_template.name}: 檢查談話頁面的主頁面時出錯：`);
+		console.error(e);
 	}
 
 	CeL.info(`${maintain_VA_template.name}: 處理 ${Object.keys(have_to_edit_its_talk_page).length} 個談話頁面。`);

--- a/routine/20201008.fix_anchor.js
+++ b/routine/20201008.fix_anchor.js
@@ -1889,7 +1889,8 @@ async function check_page(target_page_data, options) {
 		try {
 			await tracking_section_title_history(target_page_data, { section_title_history });
 		} catch (e) {
-			console.error(error);
+			CeL.error(`${check_page.name}: Cannot track the section title history of ${CeL.wiki.title_link_of(target_page_data)}:`);
+			console.error(e);
 		}
 		CeL.info(`${check_page.name}: There are ${Object.keys(section_title_history).length} section title records in page revisions of ${CeL.wiki.title_link_of(target_page_data)}. Continue to check ${working_queue_Set.size} page(s).`);
 		//console.trace(section_title_history);

--- a/routine/20210701.import_PubMed_to_wikidata.js
+++ b/routine/20210701.import_PubMed_to_wikidata.js
@@ -2226,6 +2226,8 @@ async function fetch_ORCID_data_from_service(ORCID) {
 			JSON.from_XML((await (await CeL.fetch(`https://pub.orcid.org/v3.0/${ORCID}/${type}`)).text()).replace(/(<\/?)(\w+):\2([ >])/g, '$1$2$3'))[type]
 				.forEach(item => put_to_data(type === 'record' ? ORC_data : (ORC_data.person[type] = Object.create(null)), item));
 		} catch (e) {
+			// e.g., 該 ORCID 不存在，或 pub.orcid.org 無回應。無資料可用，因此放棄本 ORCID。
+			CeL.warn(`${fetch_ORCID_data_from_service.name}: Cannot get the ${type} of ORCID ${ORCID}: ${e}`);
 			return;
 		}
 	}

--- a/routine/20210923.update_foreign_featured_contents_list.js
+++ b/routine/20210923.update_foreign_featured_contents_list.js
@@ -750,7 +750,13 @@ ORDER BY DESC(?count)
 			if (e.code === 'contenttoobig') {
 				console.trace((Buffer.from(content_to_write, 'utf8')).length + ' bytes to write.');
 			}
-			//console.trace(e);
+			// nocreate: 頁面不存在時不創建頁面，屬預期中的情況。
+			if (e.code === 'missingtitle') {
+				CeL.debug(`Skip the non-existent page ${CeL.wiki.title_link_of(page_title)}.`, 1);
+			} else {
+				CeL.error(`Cannot edit ${CeL.wiki.title_link_of(page_title)}:`);
+				console.error(e);
+			}
 		}
 
 		return page_title;

--- a/routine/20211203.synchronizing_common_pages.js
+++ b/routine/20211203.synchronizing_common_pages.js
@@ -554,7 +554,10 @@ async function edit_page(source_page_title, target_page_title, options) {
 					)})` : '')
 			});
 		} catch (e) {
-			//CeL.error(e);
+			CeL.error(`${edit_page.name}: `
+				// gettext_config:{"id":"cannot-edit-$1"}
+				+ CeL.gettext('Cannot edit %1', CeL.wiki.title_link_of(target_page_title)));
+			console.error(e);
 		}
 	}
 

--- a/task/process_dump.js
+++ b/task/process_dump.js
@@ -19,8 +19,12 @@
 require('./wiki loader.js');
 
 function process_data(error) {
-	if (error)
-		CeL.error(error);
+	if (error) {
+		CeL.error('process_data: Cannot setup the database connection:');
+		console.error(error);
+		process.exitCode = 1;
+		return;
+	}
 
 	var start_read_time = Date.now(),
 	// max_length = 0,
@@ -102,8 +106,12 @@ function process_data(error) {
 				revision.timestamp.slice(0, -1).replace('T', ' '),
 						content ]
 			}, function(error) {
-				if (error)
-					CeL.error(error);
+				if (error) {
+					CeL.error('process_data: Cannot insert [[' + page_data.title
+							+ ']] into the database:');
+					console.error(error);
+					process.exitCode = 1;
+				}
 			});
 		}
 
@@ -155,16 +163,25 @@ function process_data(error) {
 
 				if (!do_realtime_import) {
 					setup_SQL(function(error) {
-						if (error)
-							CeL.error(error);
+						if (error) {
+							CeL.error('process_data: Cannot setup the database:');
+							console.error(error);
+							process.exitCode = 1;
+							endding();
+							return;
+						}
 
 						CeL.info('process_data: Import data to database...');
 						var SQL = LOAD_DATA_SQL + file_stream.path
 								+ LOAD_DATA_SQL_post;
 						CeL.log(SQL.replace(/\n/g, '\\n'));
 						connection.query(SQL, function(error, rows) {
-							if (error)
-								CeL.error(error);
+							if (error) {
+								CeL.error('process_data: Cannot import data'
+										+ ' to the database:');
+								console.error(error);
+								process.exitCode = 1;
+							}
 							endding();
 						});
 					});
@@ -179,10 +196,18 @@ function process_data(error) {
 function setup_SQL(callback) {
 	CeL.info('setup_SQL: Re-creating database...');
 	SQL_session = new CeL.wiki.SQL(database_name, function(error) {
-		if (error)
-			CeL.error(error);
+		if (error) {
+			// 無法連線時不可繼續使用 connection。
+			callback(error);
+			return;
+		}
 
 		connection.query('DROP TABLE `' + table_name + '`', function(error) {
+			if (error) {
+				// 資料表本來就不存在時也會出錯，因此僅記錄而不中斷作業。
+				CeL.debug('setup_SQL: Cannot drop table `' + table_name + '`: '
+						+ error, 1);
+			}
 			connection.query(CREATE_SQL, callback);
 		});
 
@@ -263,8 +288,10 @@ lastest_revid = [];
 
 if (do_realtime_import) {
 	setup_SQL(function(error) {
-		if (error)
-			CeL.error(error);
+		if (error) {
+			process_data(error);
+			return;
+		}
 
 		// FATAL ERROR: JS Allocation failed - process out of memory
 		// Aborted

--- a/wiki loader.js
+++ b/wiki loader.js
@@ -82,7 +82,15 @@ require('./wiki configuration.js');
 try {
 	require('./_CeL.loader.nodejs.js');
 } catch (e) {
-	require('cejs');
+	try {
+		require('cejs');
+	} catch (e_npm) {
+		console.error('wiki loader: Cannot load local CeJS loader:');
+		console.error(e);
+		console.error('wiki loader: Cannot load the `cejs` module either. '
+				+ 'Please run `npm i cejs`.');
+		throw e_npm;
+	}
 }
 
 // for i18n: define gettext() user domain resources location.
@@ -117,7 +125,9 @@ if (_global.on_load_CeL) {
 		// e.g., in `./wiki configuration.js`
 		_global.on_load_CeL();
 	} catch (e) {
-		// TODO: handle exception
+		CeL.error('wiki loader: on_load_CeL() failed. '
+				+ 'Please check `./wiki configuration.js`:');
+		console.error(e);
 	}
 	delete _global.on_load_CeL;
 }
@@ -127,7 +137,10 @@ if (!_global.Wikiapi) {
 		// Load wikiapi module.
 		_global.Wikiapi = require('wikiapi');
 	} catch (e) {
-		// TODO: handle exception
+		// The `wikiapi` module is optional: only tasks using Wikiapi need it.
+		CeL.warn('wiki loader: Cannot load the `wikiapi` module. '
+				+ 'Tasks using Wikiapi will fail. Please run `npm i wikiapi`: '
+				+ e);
 	}
 }
 
@@ -289,7 +302,10 @@ _global.set_language = function set_language(language) {
 			// change to the bot directory.
 			process.chdir(bot_directory);
 		} catch (e) {
-			// TODO: handle exception
+			// 無法切換工作目錄時，衍生檔案將被寫到非預期的位置。
+			CeL.error('wiki loader: Cannot change working directory to ['
+					+ bot_directory + ']. Will keep using [' + original_directory
+					+ ']: ' + e);
 		}
 	}
 };


### PR DESCRIPTION
## Summary

Audit of `catch`/error-callback handling outside `archive/`. Several places dropped errors on the floor (`catch (e) { /* TODO */ }`), continued running against broken state, or masked the real error with a follow-up crash. Each site now either reports the error or aborts, while genuinely-expected failures (missing cache file, table that does not exist yet, malformed URI) are kept non-fatal but documented/logged at debug level.

Concrete bugs fixed (not just logging):

- `replace/replace_tool.js` — `get_move_configuration_from_section()`: after a failed `JSON.parse` of a `<syntaxhighlight lang="json">` block, `task_configuration` was `undefined` and the very next line threw `TypeError: Cannot read properties of undefined`, hiding the actual JSON error. Now `return`s after reporting.
- `replace/replace_tool.js` — `Template:リンク修正依頼/改名` `options=`: when `no_export` was set, an unparsable `options` was silently kept as a **string**, and `{...task_options}` then spread it character-by-character into the task configuration (`{0:'{', 1:'"', ...}`). Now the error is always reported and the value discarded.
- `routine/20201008.fix_anchor.js` — `catch (e) { console.error(error); }` referenced an undefined `error`, turning any tracking failure into a `ReferenceError` inside the catch block.
- `routine/20160915.TaiBNET.js` — `try { if (statSync(csv)) import_data(); } catch { download() }` treated *any* `import_data()` failure as "CSV missing" and re-downloaded. Split into `existsSync()` + `import_data()`, plus an `'error'` listener on the `wget` child process.
- `task/process_dump.js` — SQL errors were logged then execution continued against an unusable `connection`. `setup_SQL()` now propagates the connection error to its callback (`callback(error); return;`), query failures set `process.exitCode = 1`, and the expected `DROP TABLE` failure is demoted to `CeL.debug`.
- `check_parser.js` — `fs.writeFile()` without a callback (throws on modern Node); added an error-reporting callback and wrapped the page-list `JSON.parse`.

Logging-only changes: `wiki loader.js` (`on_load_CeL()` failures, missing `wikiapi`/`cejs`, failed `process.chdir()` — which silently sends all derived files to the wrong directory), `routine/20211203.synchronizing_common_pages.js` and `routine/20210923.update_foreign_featured_contents_list.js` (failed `edit_page()` calls were invisible; `missingtitle` under `nocreate` stays quiet), `routine/20210701.import_PubMed_to_wikidata.js` (ORCID fetch), `routine/20160414.import_label_from_wiki_link.js` (cache deletion now only ignores `ENOENT`), `routine/20200122.update_vital_articles.js`.

All touched files pass `node --check`.


Link to Devin session: https://app.devin.ai/sessions/3b889869f23649fe8b84af457189ae6b
Requested by: @kanasimi
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kanasimi/wikibot/pull/62" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->